### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy Backend to Azure
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/obsidian-plugin/security/code-scanning/4](https://github.com/billlzzz10/obsidian-plugin/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/deploy-backend.yml`. This block can be added at the root level (applies to all jobs) or at the job level (applies only to the specified job). Since there is only one job in this workflow, adding it at the root is simplest and most maintainable. The minimal recommended permission is `contents: read`, which allows the workflow to read repository contents but not write to them. If the workflow requires additional permissions (e.g., to create issues or pull requests), those can be added, but based on the provided steps, only read access is needed.

The change should be made at the top of the file, after the `name:` line and before the `on:` block. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
